### PR TITLE
Formatting and unnecessary commandline args

### DIFF
--- a/liblouis.Net.ConsoleApp/Program.cs
+++ b/liblouis.Net.ConsoleApp/Program.cs
@@ -10,7 +10,7 @@ namespace liblouis.Net.ConsoleApp
         [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
         static extern bool SetDllDirectory(string lpPathName);
 
-        static void Main(string[] args)
+        static void Main()
         {
             SetDllDirectory(@"C:\Program Files (x86)\NVDA");
             String intje = "hoi";

--- a/liblouis.Net.Test/UnitTest1.cs
+++ b/liblouis.Net.Test/UnitTest1.cs
@@ -8,7 +8,6 @@ namespace liblouis.Test
         [Fact]
         public void Test1()
         {
-
         }
     }
 }

--- a/liblouis.Net/Library.cs
+++ b/liblouis.Net/Library.cs
@@ -24,6 +24,7 @@ namespace liblouis.Net
             byte[] outbuf,
             [Out]
             int length,
-            int mode);
+            int mode
+        );
     }
 }

--- a/liblouis.Net/Widechar_CustomMarshaler.cs
+++ b/liblouis.Net/Widechar_CustomMarshaler.cs
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;


### PR DESCRIPTION
I did some formatting to make it more .NET-ish, and also removed "string[] args" in the Main() function of the Console App, we're not excepting commandline args, so it wasn't necessary.